### PR TITLE
Save Locked status even if the user is editing a draft, and only lock entries on the currently editing site

### DIFF
--- a/src/LockedEntries.php
+++ b/src/LockedEntries.php
@@ -32,7 +32,7 @@ use yii\base\Event;
  */
 class LockedEntries extends Plugin
 {
-    public string $schemaVersion = '1.0.0';
+    public string $schemaVersion = '1.0.1';
     public bool $hasCpSettings = true;
 
     public static function config(): array
@@ -102,6 +102,10 @@ class LockedEntries extends Plugin
 
 
                 $entry = $e->sender;
+                // Check if the entry being saved is a draft, and use its canonicalId if so
+                $entryId = ($entry->isDraft && $entry->canonicalId) ? $entry->canonicalId : $entry->id;
+                // The entry could exist in multiple sites, and locking should only affect the current site
+                $currentSiteId = Craft::$app->sites->currentSite->id;
                 $request = Craft::$app->getRequest();
                 // Check if the "locked" field was submitted and set
                 $isLocked = $request->getBodyParam(Constants::PLUGIN_FIELD_NAME, false);
@@ -110,20 +114,21 @@ class LockedEntries extends Plugin
                 if ($isLocked) {
                     // Check if this entry is already locked
                     $recordExists = LockedEntry::find()
-                        ->where(['entry_id' => $entry->id])
+                        ->where(['entry_id' => $entryId, 'site_id' => $currentSiteId])
                         ->exists();
 
                     // If it's locked and doesn't exist in the table, add it
                     if (!$recordExists) {
                         $lockedEntry = new LockedEntry([
-                            'entry_id' => $entry->id,
+                            'entry_id' => $entryId,
                             'user_id' => $user->id,
+                            'site_id' => $currentSiteId,
                         ]);
                         $lockedEntry->save();
                     }
                 } else {
                     // If not locked, remove it from the custom database table
-                    LockedEntry::deleteAll(['entry_id' => $entry->id]);
+                    LockedEntry::deleteAll(['entry_id' => $entryId, 'site_id' => $currentSiteId]);
                 }
             }
         );
@@ -136,7 +141,7 @@ class LockedEntries extends Plugin
                 $entry = $event->sender;
 
                 // Remove the record from our table
-                LockedEntry::deleteAll(['entry_id' => $entry->id]);
+                LockedEntry::deleteAll(['entry_id' => $entry->id, 'site_id' => $entry->siteId]);
             }
         );
 
@@ -152,7 +157,7 @@ class LockedEntries extends Plugin
 
                 $entry = $event->element;
                 $lockedEntry = LockedEntry::find()
-                    ->where(['entry_id' => $entry->id])
+                    ->where(['entry_id' => $entry->id, 'site_id' => $entry->siteId])
                     ->one();
 
                 // Check if this entry is locked
@@ -251,13 +256,15 @@ class LockedEntries extends Plugin
      */
     protected function getLockedFieldHtml(Entry $entry): string
     {
-        $lockedEntry = LockedEntry::find()->where(['entry_id' => $entry->id])->exists();
+        // Check the canonicalId if we editing a draft
+        $entryId = ($entry->isDraft && $entry->canonicalId) ? $entry->canonicalId : $entry->id;
+        $lockedEntry = LockedEntry::find()->where(['entry_id' => $entryId, 'site_id' => $entry->siteId])->exists();
         $lockedField = Cp::lightswitchFieldHtml([
-                'id' => Constants::PLUGIN_FIELD_NAME,
-                'label' => Craft::t(Constants::PLUGIN_HANDLE, 'Locked'),
-                'name' => Constants::PLUGIN_FIELD_NAME,
-                'on' => $lockedEntry ?? false,
-            ]);
+            'id' => Constants::PLUGIN_FIELD_NAME,
+            'label' => Craft::t(Constants::PLUGIN_HANDLE, 'Locked'),
+            'name' => Constants::PLUGIN_FIELD_NAME,
+            'on' => $lockedEntry ?? false,
+        ]);
 
         return Html::beginTag('fieldset') .
             Html::tag('div', $lockedField, ['class' => 'meta']) .

--- a/src/migrations/m260513_134332_AddSiteId.php
+++ b/src/migrations/m260513_134332_AddSiteId.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace alxmerino\lockedentries\migrations;
+
+use alxmerino\lockedentries\Constants;
+use Craft;
+use craft\db\Migration;
+
+/**
+ * m260513_134332_AddSiteId migration.
+ */
+class m260513_134332_AddSiteId extends Migration
+{
+    private string $tableName = Constants::PLUGIN_TABLE_NAME;
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->addColumn($this->tableName, 'site_id', $this->integer());
+        $this->createIndex($this->db->getIndexName() . '_site_id', $this->tableName, 'site_id');
+        $this->addForeignKey(
+            $this->db->getForeignKeyName() . '_site_id',
+            $this->tableName,
+            'site_id',
+            '{{%sites}}',
+            'id',
+            'CASCADE',
+            'CASCADE'
+        );
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        $this->dropIndexIfExists($this->tableName, 'site_id');
+        if ($this->db->columnExists($this->tableName, 'site_id')) {
+            $this->dropColumn($this->tableName, 'site_id');
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
First of, thanks for authoring the plugin in the first place. My team is using it in a production environment, and our content editors are using it frequently.
In doing so, they have requested a change for it -- as the project we're using it in has multiple different language variants, the same editor is not responsible for every language version of an entry, so I've added a `site_id` column in the schema which only locks the entry for the current site, instead of every site the entry is being saved to.

I also took the liberty to address the [currently open issue](https://github.com/Alxmerino/craft-locked-entries/issues/3), by checking the canonical element and only saving those entry IDs to the database.